### PR TITLE
omsMAXv.cpp: Casting between unsigned long and pointer

### DIFF
--- a/omsAsynApp/src/omsMAXv.cpp
+++ b/omsAsynApp/src/omsMAXv.cpp
@@ -166,7 +166,7 @@ void omsMAXv::initialize(const char* portName, int numAxes, int cardNo, const ch
     if (vmeAddr == 1)
         probeAddr = baseAddress + (cardNo * boardAddrSize);
     else
-        probeAddr = (void*) vmeAddr;
+        probeAddr = (void*)(size_t)vmeAddr;
 
     startAddr = (epicsUInt8 *) probeAddr;
     endAddr = startAddr + boardAddrSize;
@@ -192,7 +192,7 @@ void omsMAXv::initialize(const char* portName, int numAxes, int cardNo, const ch
 
     if (status) {
         errlogPrintf("%s:%s:%s: Can't register address 0x%lx \n",
-                        driverName, functionName, portName, (long unsigned int) probeAddr);
+                     driverName, functionName, portName, (long unsigned int)(size_t)probeAddr);
         return;
     }
 
@@ -502,7 +502,7 @@ extern "C" int omsMAXvSetup(
         return 1;
     }
     omsMAXv::numCards = num_cards;
-    omsMAXv::baseAddress = (char *) addrs;
+    omsMAXv::baseAddress = (char *) (size_t)addrs;
 
     switch (addr_type)
     {


### PR DESCRIPTION
On most system the size of a pointer is the same as the size of "long".
One exception is Win64, where a pointer uses 64 bits and the "long"
is 32 bits.
This code is (as today) not used on a Windows 64 bit platform,
so silence the compiler warnings for this platforms by casting a pointer
to size_t and then "down" to "unsigned long".
This allows continous integration to pass.