### PR TITLE
Fixed building the example IOC on Windows

### DIFF
--- a/iocs/omsAsynIOC/omsAsynApp/src/Makefile
+++ b/iocs/omsAsynIOC/omsAsynApp/src/Makefile
@@ -25,7 +25,10 @@ omsAsyn_DBD += drvAsynSerialPort.dbd
 omsAsyn_DBD += drvAsynIPPort.dbd
 #endif
 omsAsyn_DBD += motorSupport.dbd
-omsAsyn_DBD += omsAsynSupport.dbd
+omsAsyn_DBD_Linux += omsAsynSupport.dbd
+omsAsyn_DBD_vxWorks += omsAsynSupport.dbd
+omsAsyn_DBD_Win32 += omsAsynMAXnetSupport.dbd
+omsAsyn_DBD_Win64 += omsAsynMAXnetSupport.dbd
 
 # Add all the support libraries needed by this IOC
 omsAsyn_LIBS += omsAsyn

--- a/omsAsynApp/src/Makefile
+++ b/omsAsynApp/src/Makefile
@@ -8,6 +8,7 @@ include $(TOP)/configure/CONFIG
 #USR_CXXFLAGS += -DDEBUG
 
 DBD += omsAsynSupport.dbd
+DBD += omsAsynMAXnetSupport.dbd
 
 LIBRARY_IOC_DEFAULT += omsAsyn
 

--- a/omsAsynApp/src/omsAsynMAXnetSupport.dbd
+++ b/omsAsynApp/src/omsAsynMAXnetSupport.dbd
@@ -1,0 +1,4 @@
+registrar(OmsMAXnetAsynRegister)
+#variable(motorOMSBASEdebug)
+#variable(motorMAXnetdebug)
+


### PR DESCRIPTION
Added omsAsynMAXnetSupport.dbd so the MAXnet support can be included in IOCs on OSes that don't support the MAXv, like Windows.